### PR TITLE
Add instruction of how to run 'hashnet.bin' in the background as a systemd service in Linux

### DIFF
--- a/Release/README.md
+++ b/Release/README.md
@@ -15,42 +15,6 @@ Example: `hashnet.exe server.tessie.club MY_RIG1`
 Download the `hashnet.bin` file and run with `./hashnet.bin server.tessie.club your_miner_id`.
 Example: `while true; do ./hashnet.bin server.tessie.club MY_RIG1;done`
 
-++ How to run 'hashnet.bin' in the background as a systemd service:
-**Enter sudo mode: `sudo su`
-**Download the latest release (in this case it is 1.3, if a newer one is released, simply edit the part after /download/*.*/): `wget -P /root/hashnet https://github.com/invpe/HashNet/releases/download/1.3/hashnet.bin`
-then run: `chmod +x /root/hashnet/hashnet.bin`
-**Create an '.sh' file: Create a new file in desired directory (in this case it will be /root/hashnet): `nano /root/hashnet/hashnet.sh` and add the following lines to it (modify the last parameter with your's pool name):
-#!/bin/bash
-/root/hashnet/hashnet.bin server.tessie.club NAME_OF_YOUR_POOL;
-
-**Save the file (Ctrl+O), exit the editor (Ctrl+X) and run the following command:
-`chmod +x /root/hashnet/hashnet.sh`
-
-**Create a Service File: Create a new service in `/etc/systemd/system/`. Run: `nano /etc/systemd/system/hashnet.service`
-**Edit the Service File**: Add the following content:
-   
-[Unit]
-Description=Hashnet
-
-[Service]
-User=root
-WorkingDirectory=/root/hashnet
-ExecStart=/root/hashnet/hashnet.sh
-Type=simple
-Restart=always
-RestartSec=60s
-
-[Install]
-WantedBy=multi-user.target
-
-**Save the file (Ctrl+O), exit the editor (Ctrl+X)
-**Reload Systemd**: Run `systemctl daemon-reload` to reload systemd manager configuration.
-**Enable the Service**: Use `systemctl enable hashnet.service` to enable the service to start at boot.
-**Start the Service**: Start the service with `systemctl start hashnet.service`
-**Check Status**: Verify the service status using `systemctl status hashnet.service`
-
-Logs can be monitored via `journalctl -u hashnet.service -n 20` where after -n you can specify the number of lines which will be prompted.
-
 ## ESP32
 
 1. Download the `esp32merged.bin` file 
@@ -61,3 +25,57 @@ Logs can be monitored via `journalctl -u hashnet.service -n 20` where after -n y
 ## iOS - Iphones, IPADs
 
 You have to be invited to the TestFlight in order to join with your phone or tablet, let us know you are interested.
+
+---
+### How to run 'hashnet.bin' in the background as a systemd service for Linux:
+
+**Enter sudo mode**: `sudo su`
+
+**Download the latest release**:    
+in this case it is 1.3, if a newer one is released, simply edit the part after /download : `wget -P /root/hashnet https://github.com/invpe/HashNet/releases/download/1.3/hashnet.bin`  
+then run: `chmod +x /root/hashnet/hashnet.bin`
+
+**Create an '.sh' file**: Create a new file in desired directory (in this case it will be /root/hashnet): `nano /root/hashnet/hashnet.sh` and add the following lines to it (modify the last parameter with your's pool name):
+
+#!/bin/bash     
+/root/hashnet/hashnet.bin server.tessie.club NAME_OF_YOUR_POOL;
+
+**Save the file (Ctrl+O), exit the editor (Ctrl+X) and run the following command**:
+`chmod +x /root/hashnet/hashnet.sh`
+
+**Create a Service File**: Create a new service in `/etc/systemd/system/`. Run: `nano /etc/systemd/system/hashnet.service`
+
+**Edit the Service File**: Add the following content:
+   
+[Unit]  
+Description=Hashnet
+
+[Service]   
+User=root   
+WorkingDirectory=/root/hashnet  
+ExecStart=/root/hashnet/hashnet.sh  
+Type=simple 
+Restart=always  
+RestartSec=60s
+
+[Install]   
+WantedBy=multi-user.target   
+
+**Save the file (Ctrl+O), exit the editor (Ctrl+X)**
+
+**Reload Systemd**: Run `systemctl daemon-reload` to reload systemd manager configuration.
+
+**Enable the Service**: Use `systemctl enable hashnet.service` to enable the service to start at boot.
+
+**Start the Service**: Start the service with `systemctl start hashnet.service`
+
+**Check Status**: Verify the service status using `systemctl status hashnet.service`
+
+Logs can be monitored via `journalctl -u hashnet.service -n 20` where after -n you can specify the number of lines which will be prompted.
+**Save the file (Ctrl+O), exit the editor (Ctrl+X)
+**Reload Systemd**: Run `systemctl daemon-reload` to reload systemd manager configuration.
+**Enable the Service**: Use `systemctl enable hashnet.service` to enable the service to start at boot.
+**Start the Service**: Start the service with `systemctl start hashnet.service`
+**Check Status**: Verify the service status using `systemctl status hashnet.service`
+
+Logs can be monitored via `journalctl -u hashnet.service -n 20` where after -n you can specify the number of lines which will be prompted.``

--- a/Release/README.md
+++ b/Release/README.md
@@ -15,7 +15,7 @@ Example: `hashnet.exe server.tessie.club MY_RIG1`
 Download the `hashnet.bin` file and run with `./hashnet.bin server.tessie.club your_miner_id`.
 Example: `while true; do ./hashnet.bin server.tessie.club MY_RIG1;done`
 
--- How to run 'hashnet.bin' in the background as a systemd service:
+++ How to run 'hashnet.bin' in the background as a systemd service:
 **Enter sudo mode: `sudo su`
 **Download the latest release (in this case it is 1.3, if a newer one is released, simply edit the part after /download/*.*/): `wget -P /root/hashnet https://github.com/invpe/HashNet/releases/download/1.3/hashnet.bin`
 then run: `chmod +x /root/hashnet/hashnet.bin`

--- a/Release/README.md
+++ b/Release/README.md
@@ -15,6 +15,42 @@ Example: `hashnet.exe server.tessie.club MY_RIG1`
 Download the `hashnet.bin` file and run with `./hashnet.bin server.tessie.club your_miner_id`.
 Example: `while true; do ./hashnet.bin server.tessie.club MY_RIG1;done`
 
+-- How to run 'hashnet.bin' in the background as a systemd service:
+**Enter sudo mode: `sudo su`
+**Download the latest release (in this case it is 1.3, if a newer one is released, simply edit the part after /download/*.*/): `wget -P /root/hashnet https://github.com/invpe/HashNet/releases/download/1.3/hashnet.bin`
+then run: `chmod +x /root/hashnet/hashnet.bin`
+**Create an '.sh' file: Create a new file in desired directory (in this case it will be /root/hashnet): `nano /root/hashnet/hashnet.sh` and add the following lines to it (modify the last parameter with your's pool name):
+#!/bin/bash
+/root/hashnet/hashnet.bin server.tessie.club NAME_OF_YOUR_POOL;
+
+**Save the file (Ctrl+O), exit the editor (Ctrl+X) and run the following command:
+`chmod +x /root/hashnet/hashnet.sh`
+
+**Create a Service File: Create a new service in `/etc/systemd/system/`. Run: `nano /etc/systemd/system/hashnet.service`
+**Edit the Service File**: Add the following content:
+   
+[Unit]
+Description=Hashnet
+
+[Service]
+User=root
+WorkingDirectory=/root/hashnet
+ExecStart=/root/hashnet/hashnet.sh
+Type=simple
+Restart=always
+RestartSec=60s
+
+[Install]
+WantedBy=multi-user.target
+
+**Save the file (Ctrl+O), exit the editor (Ctrl+X)
+**Reload Systemd**: Run `systemctl daemon-reload` to reload systemd manager configuration.
+**Enable the Service**: Use `systemctl enable hashnet.service` to enable the service to start at boot.
+**Start the Service**: Start the service with `systemctl start hashnet.service`
+**Check Status**: Verify the service status using `systemctl status hashnet.service`
+
+Logs can be monitored via `journalctl -u hashnet.service -n 20` where after -n you can specify the number of lines which will be prompted.
+
 ## ESP32
 
 1. Download the `esp32merged.bin` file 

--- a/Release/README.md
+++ b/Release/README.md
@@ -54,7 +54,7 @@ Description=Hashnet
 User=root   
 WorkingDirectory=/root/hashnet  
 ExecStart=/root/hashnet/hashnet.sh  
-Type=simple 
+Type=simple   
 Restart=always  
 RestartSec=60s
 

--- a/Release/README.md
+++ b/Release/README.md
@@ -72,10 +72,3 @@ WantedBy=multi-user.target
 **Check Status**: Verify the service status using `systemctl status hashnet.service`
 
 Logs can be monitored via `journalctl -u hashnet.service -n 20` where after -n you can specify the number of lines which will be prompted.
-**Save the file (Ctrl+O), exit the editor (Ctrl+X)
-**Reload Systemd**: Run `systemctl daemon-reload` to reload systemd manager configuration.
-**Enable the Service**: Use `systemctl enable hashnet.service` to enable the service to start at boot.
-**Start the Service**: Start the service with `systemctl start hashnet.service`
-**Check Status**: Verify the service status using `systemctl status hashnet.service`
-
-Logs can be monitored via `journalctl -u hashnet.service -n 20` where after -n you can specify the number of lines which will be prompted.``


### PR DESCRIPTION
Add instruction of how to run 'hashnet.bin' in the background as a systemd service in Linux.